### PR TITLE
Resolve GitHub token issue

### DIFF
--- a/.github/workflows/trigger-extremely-dangerous-oidc-beacon.yml
+++ b/.github/workflows/trigger-extremely-dangerous-oidc-beacon.yml
@@ -69,7 +69,8 @@ jobs:
           curl -L \
             --fail \
             -X POST \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "${REPO_URL}/actions/workflows/${BEACON_NAME}/dispatches"
-            -d '{"ref":"${GITHUB_REF_NAME}"}'
+            "${REPO_URL}/actions/workflows/${BEACON_NAME}/dispatches" \
+            -d '{"ref":"${{ github.ref }}"}' \


### PR DESCRIPTION
Fixes the regression introduced in #2, see https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/actions/runs/4928197053/jobs/8806248763.

GITHUB_TOKEN isn't an environment variable, it's a secret.

Working run:
https://github.com/trail-of-forks/extremely-dangerous-public-oidc-beacon/actions/runs/4928291821