### PR TITLE
workflows: use most recent stable Python

### DIFF
--- a/.github/workflows/extremely-dangerous-oidc-beacon.yml
+++ b/.github/workflows/extremely-dangerous-oidc-beacon.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.x"
       - name: Retrieve OIDC token
         run: |
           python -m pip install id &&


### PR DESCRIPTION
The beacon here is currently broken, since Pydantic is currently broken on Python 3.7 (which is EOL anyways).

I've tweaked the workflow to resolve to the latest stable Python, which should be more reliable. I've also manually triggered it and confirmed that these changes work.