### PR TITLE
dependabot: keep actions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99
+    rebase-strategy: "disabled"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This isn't a fix for #4, but will ameliorate it somewhat (by ensuring more regular repo activity).