### PR TITLE
Publish OIDC beacon in branch

### DIFF
--- a/.github/workflows/extremely-dangerous-oidc-beacon.yml
+++ b/.github/workflows/extremely-dangerous-oidc-beacon.yml
@@ -18,39 +18,33 @@ permissions: {}
 jobs:
   upload-extremely-dangerous-token:
     permissions:
-      # Needed to access the workflow's OIDC identity.
-      id-token: write
+      id-token: write # For OIDC authentication
+      contents: write # For pushing to current-token branch
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Retrieve OIDC token
         run: |
-          mkdir token_artifact_dir
-          python -m pip install id &&
-          python -m id sigstore > token_artifact_dir/oidc-token.txt
+          python -m pip install id
+          python -m id sigstore > oidc-token.txt
+
+      - name: Push ephemeral current-token branch
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "noreply@github.com"
+          git add oidc-token.txt
+          git commit -m "Ephemeral commit with current token"
+          git push --force origin HEAD:current-token
+
       - name: Upload OIDC token artifact (legacy)
         uses: actions/upload-artifact@v4.3.1
         with:
           name: oidc-token
-          path: token_artifact_dir/oidc-token.txt
-      - name: Upload OIDC token artifact for GitHub Pages
-        uses: actions/upload-pages-artifact@v3.0.1
-        with:
-          path: token_artifact_dir/
-
-  deploy-extremely-dangerous-token:
-    permissions:
-      pages: write
-      id-token: write # for authenticating to GH Pages
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: upload-extremely-dangerous-token
-    steps:
-      - name: Deploy extremely dangerous token to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4.0.4
+          path: ./oidc-token.txt

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ names also include `extremely-dangerous` to emphasize that identity tokens
 originating from them must not be trusted for anything except testing purposes.
 
 Because GitHub workflow scheduling is best-effort, the published token may sometimes
-be expired for a while. Users may want to retry a little later in these cases (the
-provided GitHub Action handles this).
+be expired for a while. Users may want to retry a little later in these cases like
+the provided GitHub Action does.
 
 [conformance testing]: https://github.com/sigstore/sigstore-conformance

--- a/README.md
+++ b/README.md
@@ -1,19 +1,33 @@
 # extremely-dangerous-public-oidc-beacon
 
-This repository exists to provide two workflows:
-`extremely-dangerous-oidc-beacon.yml` and
-`trigger-extremely-dangerous-oidc-beacon.yml`.
+This repository publishes an OIDC identity token for testing purposes.
+This OIDC token should not be trusted, but it can be useful for testing
+Sigstore keyless signing and verification, see e.g. [conformance testing].
 
-`trigger-extremely-dangerous-oidc-beacon.yml` dispatches
+## Usage
+
+The repository includes an action that will download the current token into
+working directory (`./oidc-token.txt`):
+
+    - uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@main
+
+## Details
+
+The workflow `trigger-extremely-dangerous-oidc-beacon.yml` dispatches
 `extremely-dnagerous-oidc-beacon.yml` on a schedule. The latter *intentionally*
-leaks an OIDC identity token corresponding to its workflow identity. It does this
-so that members of the Sigstore community have access to a uniform identity token
-for [conformance testing].
+leaks an OIDC identity token corresponding to its workflow identity. The token is
+made available in the workflow artifacts and also in an ephemeral (force-pushed)
+git branch
+[current-token](https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/tree/current-token).
 
-These workflows are intentionally isolated in their own repository, within
+The workflows are intentionally isolated in their own repository, within
 an otherwise unused GitHub organization, to minimize the possibility
 that users will incorrectly trust these identity tokens. The workflow
 names also include `extremely-dangerous` to emphasize that identity tokens
 originating from them must not be trusted for anything except testing purposes.
+
+Because GitHub workflow scheduling is best-effort, the published token may sometimes
+be expired for a while. Users may want to retry a little later in these cases (the
+provided GitHub Action handles this).
 
 [conformance testing]: https://github.com/sigstore/sigstore-conformance

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,11 @@ runs:
   using: "composite"
 
   steps:
-    # Note: we're using default python and assuming pyjwt is already installed
+    - name: Install dependencies
+      # this should be a no-op as it's already installed on GitHub runners
+      run: pip install pyjwt
+      shell: bash
+
     - name: Download token
       run: |
         python ${{ github.action_path }}/download-token.py

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,14 @@
+name: "Download cursed OIDC token"
+description: "Download an unsafe OIDC token to ./oidc-token.txt. This is useful for sigstore conformance testing"
+
+permissions: {}
+
+runs:
+  using: "composite"
+
+  steps:
+    # Note: we're using default python and assuming pyjwt is already installed
+    - name: Download token
+      run: |
+        python ${{ github.action_path }}/download-token.py
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,6 @@ runs:
   using: "composite"
 
   steps:
-    - name: Install dependencies
-      # this should be a no-op as it's already installed on GitHub runners
-      run: pip install pyjwt
-      shell: bash
-
     - name: Download token
       run: |
         python ${{ github.action_path }}/download-token.py

--- a/download-token.py
+++ b/download-token.py
@@ -1,0 +1,69 @@
+# Fetch a cursed OIDC token from extremely-dangerous-public-oidc-beacon git
+# 
+# This script exists for a few reasons:
+# * Multiple sigstore-related projects need a non-expired OIDC token for testing
+#   (and GitHub Actions tokens are not available in PRs for good reasons)
+# * extremely-dangerous-public-oidc-beacon project produces a token every few minutes but
+#   the tokens are short-lived: this means any fetching method with caching or latency
+#   of minutes will not work (this covers Github Pages and https://raw.githubusercontent.com/)
+# * There are times when there is no valid token available for a while
+#
+# To counter all of these issues:
+# * use git to fetch token from "current-token" branch
+# * use pyjwt to check if token is invalid (or is just about to expire)
+# * retry a bit later
+
+from datetime import datetime, timedelta
+import sys
+from tempfile import TemporaryDirectory
+import logging
+import os
+import subprocess
+import shutil
+import time
+
+import jwt
+
+MIN_VALIDITY = timedelta(seconds=10)
+MAX_RETRY_TIME = timedelta(minutes=5)
+RETRY_SLEEP_SECS = 30
+GIT_URL = "https://github.com/jku/extremely-dangerous-public-oidc-beacon.git"
+
+logger = logging.getLogger(__name__)
+
+
+def git_clone(url: str, dir: str) -> None:
+    base_cmd = ["git", "clone", "--quiet", "--branch", "current-token", "--depth", "1"]
+    subprocess.run(base_cmd + [url, dir])
+
+
+def is_valid_at(token_path: str, reference_time: datetime):
+    with open(token_path) as f:
+        token = jwt.decode(f.read().rstrip(), options={"verify_signature": False})
+    expiry = datetime.fromtimestamp(token["exp"])
+    valid = reference_time < expiry
+    logger.debug(
+        "token is %s (ref time: %s, expiry: %s)",
+        "valid" if valid else "expired",
+        reference_time,
+        expiry
+    )
+    return valid
+
+
+start_time = datetime.now()
+while True:
+    with TemporaryDirectory() as tempdir:
+        git_clone(GIT_URL, tempdir)
+
+        token_path = os.path.join(tempdir, "oidc-token.txt")
+        if is_valid_at(token_path, datetime.now() + MIN_VALIDITY):
+            shutil.copyfile(token_path, "./oidc-token.txt")
+            print("Downloaded valid token to ./oidc-token.txt")
+            break
+
+    if datetime.now() > start_time + MAX_RETRY_TIME:
+        sys.exit(f"Failed to find a valid token in {MAX_RETRY_TIME}")
+
+    print(f"Current token expires too early, retrying in {RETRY_SLEEP_SECS} seconds.")
+    time.sleep(RETRY_SLEEP_SECS)


### PR DESCRIPTION
This is an attempt to make fetching the cursed token easier for users.
* remove the GH Pages publish as it just did not work
* publish the token in "current-token" branch (force pushed: it's always current main plus the token commit)
* provide a GH action to download the token from the branch (we could just use actions/checkout but then the issue is that sometimes even the "current" token is not valid: we want git checkout + retries)

I think this might be pretty good for GH actions, see an example in https://github.com/jku/oidc-token-test/blob/main/.github/workflows/test.yml. Basically this is enough to get a `oidc-token.txt` quite reliably:

    - uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@main


for sigstore-conformance specifically we likely want to use the python code (and not use the action):
* this works locally as well -- without a GitHub token
* since we''ll soon be running the test suite twice, it might make sense to get a fresh token for each run
