### PR TITLE
use environment variable for action path instead of expression

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ runs:
   steps:
     - name: Download token
       run: |
-        python ${{ github.action_path }}/download-token.py
+        python $GITHUB_ACTION_PATH/download-token.py
       shell: bash


### PR DESCRIPTION
The `${{ github.action_path }}` expression on Windows runners has issues that prevent this composite action from working.

https://github.com/orgs/community/discussions/25910