### PR TITLE
Deprecation notice for the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # extremely-dangerous-public-oidc-beacon
 
-This repository publishes an OIDC identity token for testing purposes.
-This OIDC token should not be trusted, but it can be useful for testing
-Sigstore keyless signing and verification, see e.g. [conformance testing].
+> [!WARNING]
+> **This action is deprecated and will stop working soon.**
+>
+> All users should switch to the new test token, which is more reliable and has a longer time-to-live. The new token identity is:
+> * **Signing identity**: `untrusted-sa@sigstore-conformance.iam.gserviceaccount.com`
+> * **Issuer**: `https://accounts.google.com`
+>
+> To download it as a 1:1 replacement of running this action:
+>
+> ```bash
+> curl -sSfL https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt -o oidc-token.txt
+> ```
 
-## Usage
+## Usage (Deprecated)
 
-The repository includes an action that will download the current token into
+The repository includes an action that will download the current token into the
 working directory (`./oidc-token.txt`):
 
     - uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@main

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,11 @@ runs:
   using: "composite"
 
   steps:
+    - name: Deprecation warning
+      run: |
+        echo "::warning title=Deprecated Action::extremely-dangerous-public-oidc-beacon is deprecated and will stop working soon. All users should switch.%0A%0A    To migrate, replace this action with:%0A    curl -sSfL https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt -o oidc-token.txt%0A%0A    New token details:%0A    Identity = untrusted-sa@sigstore-conformance.iam.gserviceaccount.com%0A    Issuer = https://accounts.google.com"
+      shell: bash
+
     - name: Download token
       run: |
         python $GITHUB_ACTION_PATH/download-token.py


### PR DESCRIPTION
We don't want to maintain both the Cloud Run token publisher and this one: let's archive this repository once conformance users have upgraded

see also #62 